### PR TITLE
Noetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Build Status](https://github.com/PepperlFuchs/pf_lidar_ros_driver/actions/workflows/main.yml/badge.svg)
 
 **Required platform:**  
-Ubuntu 18.04 and ROS Melodic
+Ubuntu 20.04 and ROS Noetic
   
 **Clone the repository:**  
 Clone the repository in the `src` folder of your ROS workspace
@@ -15,13 +15,13 @@ git clone --branch=main https://github.com/PepperlFuchs/pf_lidar_ros_driver.git
 ```
 cd <path/to/workspace>
 rosdep update
-rosdep install --from-paths src --ignore-src --rosdistro=melodic -y
+rosdep install --from-paths src --ignore-src --rosdistro=noetic -y
 ```
   
 **Build the workspace:**  
 ```
 cd <path/to/workspace>
-source /opt/ros/melodic/setup.bash
+source /opt/ros/noetic/setup.bash
 catkin build
 source <path/to/workspace>/install/setup.bash
 ```

--- a/pf_driver/src/ros/scan_publisher.cpp
+++ b/pf_driver/src/ros/scan_publisher.cpp
@@ -131,11 +131,11 @@ void ScanPublisherR2300::handle_scan(sensor_msgs::LaserScanPtr msg, uint16_t lay
   publish_scan(msg, layer_idx);
   sensor_msgs::PointCloud2 c;
   if (tfListener_.waitForTransform(
-          msg->header.frame_id, "/base_link",
+          msg->header.frame_id, "base_link",
           msg->header.stamp + ros::Duration().fromSec(msg->ranges.size() * msg->time_increment), ros::Duration(1.0)))
   {
     int channelOptions = laser_geometry::channel_option::Intensity;
-    projector_.transformLaserScanToPointCloud("/base_link", *msg, c, tfListener_, -1.0, channelOptions);
+    projector_.transformLaserScanToPointCloud("base_link", *msg, c, tfListener_, -1.0, channelOptions);
     if (layer_idx <= layer_prev_)
     {
       if (!cloud_->data.empty())


### PR DESCRIPTION
The branch has been tested on `melodic` as well, so there is no need to maintain two separate branches. `main` branch will be used for release for both `melodic` and `noetic`.