### PR TITLE
Allow to disable RViz & pf_bringup in launch file.

### DIFF
--- a/src/pf_driver/launch/r2000.launch
+++ b/src/pf_driver/launch/r2000.launch
@@ -2,9 +2,16 @@
 <launch>
   <arg name="device" default="R2000"/>
 
-  <include file="$(find pf_description)/launch/pf_bringup.launch" >
-    <arg name="scanner" value="r2000" />
-  </include>
+  <arg name="launch_pf_description" default="true"
+       doc="Whether to include the pf_description bringup with this launch file." />
+  <arg name="launch_rviz" default="true"
+       doc="Whether to start RViz with this launch file." />
+
+  <group if="$(arg launch_pf_description)">
+    <include file="$(find pf_description)/launch/pf_bringup.launch" >
+      <arg name="scanner" value="r2000" />
+    </include>
+  </group>
 
   <!-- R2000 Driver -->
   <node pkg="pf_driver" type="ros_main" name="r2000_node" output="screen">
@@ -12,5 +19,7 @@
     <rosparam file="$(find pf_driver)/config/r2000_params.yaml" command="load"/>
   </node>
 
-  <node type="rviz" name="rviz" pkg="rviz" args="-d $(find pf_driver)/rviz/r2000.rviz" />
+  <group if="$(arg launch_rviz)">
+    <node type="rviz" name="rviz" pkg="rviz" args="-d $(find pf_driver)/rviz/r2000.rviz" />
+  </group>
 </launch>

--- a/src/pf_driver/launch/r2300.launch
+++ b/src/pf_driver/launch/r2300.launch
@@ -2,9 +2,16 @@
 <launch>
   <arg name="device" default="R2300"/>
 
-  <include file="$(find pf_description)/launch/pf_bringup.launch" >
-    <arg name="scanner" value="r2300" />
-  </include>
+  <arg name="launch_pf_description" default="true"
+       doc="Whether to include the pf_description bringup with this launch file." />
+  <arg name="launch_rviz" default="true"
+       doc="Whether to start RViz with this launch file." />
+
+  <group if="$(arg launch_pf_description)">
+    <include file="$(find pf_description)/launch/pf_bringup.launch" >
+      <arg name="scanner" value="r2300" />
+    </include>
+  <group>
 
   <!-- R2300 Driver -->
   <node pkg="pf_driver" type="ros_main" name="r2300_node" output="screen">
@@ -13,5 +20,7 @@
     <rosparam file="$(find pf_driver)/config/correction_params.yaml" command="load"/>
   </node>
 
-  <node type="rviz" name="rviz" pkg="rviz" args="-d $(find pf_driver)/rviz/r2300.rviz" />
+  <group if="$(arg launch_rviz)">
+    <node type="rviz" name="rviz" pkg="rviz" args="-d $(find pf_driver)/rviz/r2300.rviz" />
+  </group>
 </launch>


### PR DESCRIPTION
This allows better integration in headless systems and robots that already have a robot_state_publisher.