### PR TITLE
[WIP] safe feed time within the defined timeout

### DIFF
--- a/src/pf_driver/src/pf/pf_interface.cpp
+++ b/src/pf_driver/src/pf/pf_interface.cpp
@@ -175,7 +175,8 @@ bool PFInterface::init()
 
 void PFInterface::start_watchdog_timer(float duration)
 {
-  int feed_time = std::floor(std::min(duration, 60.0f));
+  // dividing the watchdogtimeout by 2 to have a “safe” feed time within the defined timeout
+  float feed_time = std::min(duration, 60.0f) / 2.0f;
   watchdog_timer_ =
       nh_.createTimer(ros::Duration(feed_time), std::bind(&PFInterface::feed_watchdog, this, std::placeholders::_1));
 }


### PR DESCRIPTION
Related to https://github.com/PepperlFuchs/pf_lidar_ros_driver/issues/107

protocol error (120 invalid handle) is only sent by the sensor when we send a request with handle to it. This could be: Start, Stop, Configuration of Scan, Watchdog feeding (via http)
 
Nothing on the scan is changed – so only the watchdog feed is left. An indication for this is that the error messages are with a gap of 60 s (default timeout):

``` bash
[/r2000_node INFO 1676938855.149217]: Device state changed to Running
# Here the driver is running. Watchdog is getting fed successfully for 5,2h. 
# Then suppose that one feeding came too late. This will cause the release of the handle by the R2000.
[/r2000_node INFO 1676957815.357771]: protocol error: 120 Invalid handle or no handle provided
# Feeding the watchdog is not possible anymore, because the used handle was released.
[/r2000_node INFO 1676957875.153960]: protocol error: 120 Invalid handle or no handle provided
```
The PR sets a “safe” feed within the defined timeout.